### PR TITLE
Create a special deploy stage in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
 language: python
 
+git:
+  depth: false
+
 python:
   - "3.5"
   - "3.6"
 
-git:
-  depth: false
+jobs:
+  include:
+    # special deploy stage for tag builds ONLY
+    - stage: deploy
+      if: tag IS present
+      script: skip
+      after_script: skip
+      deploy:
+        provider: pypi
+        user: "${PYPI_USERNAME}"
+        password: "${PYPI_PASSWORD}"
+        on:
+          tags: true
 
 before_install:
   - pip install --upgrade pip  # some Travis images have outdated pip


### PR DESCRIPTION
This PR creates a special deploy stage in TravisCI which is only
executed on tag builds *after* all testing stages have completed. This
is necessary because we have more than one test job (Python versions),
but we only want to deploy to PyPI after a successful tag build.
Deploying the same file to PyPI more than once is an error.