### PR TITLE
Set pydocstyle version to less than 4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ extras['dev'] = [
     'flake8-import-order',
     'pep8-naming',
     'pre-commit',
+    'pydocstyle<4.0.0',
     'pylint',
     'pytest>=3.6',  # Required for pytest-cov on Python 3.6
     'pytest-cov',


### PR DESCRIPTION
pydocstyle 4.0.0 breaks flake8-docstrings 1.3.0
See: https://gitlab.com/pycqa/flake8-docstrings/issues/36