### PR TITLE
Remove `stages` keys from .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
         name: pylint
         entry: pylint
         args: ['-j 0', '--rcfile=setup.cfg']
-        stages: [commit, push]
         language: system
         files: \.py$
 
@@ -21,45 +20,25 @@ repos:
     stages: [commit, push]
     hooks:
     -   id: check-added-large-files     # Prevent giant files from being committed.
-        stages: [commit, push]
     -   id: check-ast                   # Simply check whether files parse as valid python.
-        stages: [commit, push]
     -   id: check-byte-order-marker     # Forbid files which have a UTF-8 byte-order marker
-        stages: [commit, push]
     -   id: check-docstring-first       # Checks for a common error of placing code before the docstring.
-        stages: [commit, push]
     -   id: check-executables-have-shebangs # Checks that non-binary executables have a proper shebang.
-        stages: [commit, push]
     -   id: check-json                  # Attempts to load all json files to verify syntax.
-        stages: [commit, push]
     -   id: check-merge-conflict        # Check for files that contain merge conflict strings.
-        stages: [commit, push]
     -   id: check-symlinks              # Checks for symlinks which do not point to anything.
-        stages: [commit, push]
     -   id: check-vcs-permalinks        # Ensures that links to vcs websites are permalinks.
-        stages: [commit, push]
     -   id: check-xml                   # Attempts to load all xml files to verify syntax.
-        stages: [commit, push]
     -   id: check-yaml                  # Attempts to load all yaml files to verify syntax.
-        stages: [commit, push]
     -   id: debug-statements            # Check for debugger imports and py37+ breakpoint() calls in python source.
-        stages: [commit, push]
     -   id: detect-private-key          # Checks for the existence of private keys.
-        stages: [commit, push]
     -   id: double-quote-string-fixer   # This hook replaces double quoted strings with single quoted strings.
-        stages: [commit, push]
     -   id: end-of-file-fixer           # Makes sure files end in a newline and only a newline.
-        stages: [commit, push]
     -   id: flake8                      # Run flake8 on your python files.
-        stages: [commit, push]
     -   id: forbid-new-submodules       # Prevent addition of new git submodules.
-        stages: [commit, push]
     -   id: mixed-line-ending           # Replaces or checks mixed line ending.
-        stages: [commit, push]
     -   id: pretty-format-json          # Checks that all your JSON files have keys that are sorted and indented.
-        stages: [commit, push]
     -   id: trailing-whitespace         # Trims trailing whitespace.
-        stages: [commit, push]
 # First pass: check format
 -   repo: https://github.com/pre-commit/mirrors-yapf
     rev: v0.25.0
@@ -67,7 +46,6 @@ repos:
     -   id: yapf
         name: Check format by yapf
         args: ['-dpr']
-        stages: [commit, push]
 # Second pass: format in-place
 -   repo: https://github.com/pre-commit/mirrors-yapf
     rev: v0.25.0
@@ -75,4 +53,3 @@ repos:
     -   id: yapf
         name: Format in-place by yapf
         args: ['-ipr']
-        stages: [commit, push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,7 @@ repos:
         files: \.py$
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.3.0
-    # https://github.com/pre-commit/pre-commit-hooks/blob/master/README.md
+    rev: v1.15.0
     stages: [commit, push]
     hooks:
     -   id: check-added-large-files     # Prevent giant files from being committed.


### PR DESCRIPTION
This key was removed from pre-commit, and the new defaults match our preferred config.